### PR TITLE
Update README.md to include example of TradewindsMove

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,21 @@ nnoremap <leader>k <plug>(tradewinds-k)
 nnoremap <leader>l <plug>(tradewinds-l)
 ```
 
+Alternatively, if you want flexible bindings, you can also use the `TradewindsMove` command:
+```vim
+let g:tradewinds_no_maps = 1
+
+nnoremap <silent> <c-w>g<left>  :TradewindsMove h<CR>
+nnoremap <silent> <c-w>g<down>  :TradewindsMove j<CR>
+nnoremap <silent> <c-w>g<up>    :TradewindsMove k<CR>
+nnoremap <silent> <c-w>g<right> :TradewindsMove l<CR>
+
+nnoremap <silent> <c-w>gh :TradewindsMove h<CR>
+nnoremap <silent> <c-w>gj :TradewindsMove j<CR>
+nnoremap <silent> <c-w>gk :TradewindsMove k<CR>
+nnoremap <silent> <c-w>gl :TradewindsMove l<CR>
+```
+
 trade winds won't try to make its usual maps if you have made your own,
 and it wont step on your existing maps.
 


### PR DESCRIPTION
This will add a usage example for the `TradewindsMove` command, so that users understand how it is mapped internally and can be remapped without the `<plug>` usage.