### PR TITLE
Fire User autocmd after hard movement

### DIFF
--- a/autoload/tradewinds.vim
+++ b/autoload/tradewinds.vim
@@ -43,6 +43,7 @@ function! tradewinds#softmove(dir) abort
   " hard HJKL movements can be used here
   if l:target == 0 || l:target == winnr()
     execute 'wincmd' toupper(a:dir)
+    call s:AfterVoyage()
     return
   endif
 
@@ -112,6 +113,10 @@ function! tradewinds#softmove(dir) abort
     call win_gotoid(l:winid)
   endif
 
+  call s:AfterVoyage()
+endfunction
+
+function! s:AfterVoyage()
   if exists('#User#TradeWindsAfterVoyage')
     doautocmd <nomodeline> User TradeWindsAfterVoyage
   endif


### PR DESCRIPTION
The `TradeWindsAfterVoyage` autocmd is currently only fired after a "soft" TradeWinds movement, not after a "hard" Vim movement. However hard movements can still require statusline updates, and as a user I don't want to think about whether the movement I'm triggering is going to be performed by TradeWinds or by Vim, so this PR fires the autocmd either way.